### PR TITLE
ENG-123 PROJ-9: correlation id middleware + review metadata endpoint

### DIFF
--- a/python-service/src/app.py
+++ b/python-service/src/app.py
@@ -1,9 +1,10 @@
 import sys
 import os
+import uuid
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-from flask import Flask, request, jsonify  # noqa: E402
+from flask import Flask, request, jsonify, g  # noqa: E402
 from flask_cors import CORS  # noqa: E402
 from src.code_reviewer import CodeReviewer  # noqa: E402
 
@@ -11,11 +12,45 @@ app = Flask(__name__)
 CORS(app)
 
 reviewer = CodeReviewer()
+SUPPORTED_LANGUAGES = ["python", "javascript", "typescript", "go", "ruby", "java"]
+MODEL_VERSION = "v1"
+
+
+@app.before_request
+def set_correlation_id():
+    incoming_id = request.headers.get("X-Correlation-ID")
+    g.correlation_id = incoming_id or str(uuid.uuid4())
+
+
+@app.after_request
+def add_correlation_id_header(response):
+    correlation_id = getattr(g, "correlation_id", None)
+    if correlation_id:
+        response.headers["X-Correlation-ID"] = correlation_id
+    return response
 
 
 @app.route("/health", methods=["GET"])
 def health_check():
-    return jsonify({"status": "healthy", "service": "python-reviewer"})
+    return jsonify(
+        {
+            "status": "healthy",
+            "service": "python-reviewer",
+            "correlation_id": getattr(g, "correlation_id", None),
+        }
+    )
+
+
+@app.route("/review/metadata", methods=["GET"])
+def review_metadata():
+    return jsonify(
+        {
+            "service": "python-reviewer",
+            "model_version": MODEL_VERSION,
+            "supported_languages": SUPPORTED_LANGUAGES,
+            "correlation_id": getattr(g, "correlation_id", None),
+        }
+    )
 
 
 @app.route("/review", methods=["POST"])
@@ -44,6 +79,7 @@ def review_code():
             ],
             "suggestions": result.suggestions,
             "complexity_score": result.complexity_score,
+            "correlation_id": getattr(g, "correlation_id", None),
         }
     )
 
@@ -58,7 +94,12 @@ def review_function():
     function_code = data.get("function_code", "")
     result = reviewer.review_function(function_code)
 
-    return jsonify(result)
+    return jsonify(
+        {
+            **result,
+            "correlation_id": getattr(g, "correlation_id", None),
+        }
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
 

Implemented:
- Correlation ID middleware (`X-Correlation-ID`) via before/after request hooks
- Correlation ID propagation in JSON responses (`/health`, `/review`, `/review/function`)
- New `/review/metadata` endpoint with service metadata and supported languages

Intentionally left out for validation of missing requirements detection:
- Unit tests for middleware + metadata endpoint
- README/API documentation updates

Linked tickets : SCRUM-8 SCRUM-7