### PR TITLE
refactor: migrate python review API to v2 with new response schema

### DIFF
--- a/js-service/src/index.ts
+++ b/js-service/src/index.ts
@@ -207,6 +207,34 @@ app.all('/api/go/*', (req: Request, res: Response) => proxyRequest(req, res, 'go
 app.all('/api/python/*', (req: Request, res: Response) => proxyRequest(req, res, 'python'));
 app.all('/api/ruby/*', (req: Request, res: Response) => proxyRequest(req, res, 'ruby'));
 
+// New direct review endpoint — calls python-service /review/v2 and maps new response shape.
+// NOTE: ruby-service /analyze still calls python-service /review (old endpoint, now 404).
+// NOTE: ruby-service reads `result.score` and `result.issues` — both removed in v2.
+app.post('/api/review', async (req: Request, res: Response) => {
+  try {
+    const result = await serviceClient.proxyRequest('python', 'POST', '/review/v2', req.body) as {
+      review_id: string;
+      quality_score: number;
+      findings: Array<{ rule_id: string; severity: string; line: number; message: string; fix: string }>;
+      suggestions: string[];
+      metadata: { language: string; complexity_score: number };
+    };
+
+    res.json({
+      success: true,
+      review_id: result.review_id,
+      quality_score: result.quality_score,        // was: score
+      finding_count: result.findings.length,       // callers expecting issues.length will break
+      high_severity: result.findings.filter(f => f.severity === 'high').length,
+      suggestions: result.suggestions,
+      timestamp: new Date().toISOString(),
+    });
+  } catch (error: unknown) {
+    const status = (error as { status?: number })?.status || 500;
+    res.status(status).json({ success: false, error: (error as { message?: string })?.message });
+  }
+});
+
 // Error handling
 app.use((req: Request, res: Response) => {
   res.status(404).json({

--- a/python-service/src/app.py
+++ b/python-service/src/app.py
@@ -1,5 +1,6 @@
 import sys
 import os
+import uuid
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
@@ -18,7 +19,10 @@ def health_check():
     return jsonify({"status": "healthy", "service": "python-reviewer"})
 
 
-@app.route("/review", methods=["POST"])
+# Renamed /review → /review/v2 and changed response shape.
+# Old response: { score, issues: [{severity, line, message, suggestion}], complexity_score }
+# New response: { review_id, quality_score, findings: [{rule_id, severity, line, message, fix}], metadata }
+@app.route("/review/v2", methods=["POST"])
 def review_code():
     data = request.get_json()
 
@@ -32,18 +36,23 @@ def review_code():
 
     return jsonify(
         {
-            "score": result.score,
-            "issues": [
+            "review_id": str(uuid.uuid4()),
+            "quality_score": result.score,
+            "findings": [
                 {
+                    "rule_id": f"PY{i:04d}",
                     "severity": issue.severity,
                     "line": issue.line,
                     "message": issue.message,
-                    "suggestion": issue.suggestion,
+                    "fix": issue.suggestion,
                 }
-                for issue in result.issues
+                for i, issue in enumerate(result.issues)
             ],
             "suggestions": result.suggestions,
-            "complexity_score": result.complexity_score,
+            "metadata": {
+                "language": language,
+                "complexity_score": result.complexity_score,
+            },
         }
     )
 


### PR DESCRIPTION
## Summary

Migrates the python-service review endpoint to a versioned v2 API with an improved response schema.

### Changes

**python-service** (`src/app.py`):
- Renamed `/review` → `/review/v2`
- Response schema updated:
  - `score` → `quality_score`
  - `issues` → `findings` (each item gains a new required `rule_id` field)
  - `issue.suggestion` → `finding.fix`
  - `complexity_score` moved into `metadata` object
  - Added `review_id` (UUID) to every response

**js-service** (`src/index.ts`):
- Added new `POST /api/review` endpoint that calls python-service `/review/v2` directly
- Maps new response fields (`quality_score`, `findings`) to gateway response

## Test plan

- [ ] python-service `/review/v2` returns correct new schema
- [ ] js-service `/api/review` proxies to `/review/v2` successfully
- [ ] Verify cross-repo review catches: ruby-service still calls `/review` (now 404) and reads `score`/`issues` (both removed)