### PR TITLE
test: add php scan fixture service

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,14 @@ build:
 	cd python-service && pip install -r requirements.txt
 	@echo "Building Ruby service..."
 	cd ruby-service && bundle install
+	@echo "Preparing PHP service fixture..."
+	@if [ -d "php-service" ]; then \
+		if command -v php >/dev/null 2>&1; then \
+			php -l php-service/public/index.php >/dev/null && php -l php-service/src/LegacyReportController.php >/dev/null; \
+		else \
+			echo "Skipping PHP syntax check; php is not installed"; \
+		fi; \
+	fi
 
 test:
 	@echo "Testing Go service..."
@@ -24,6 +32,14 @@ test:
 	cd python-service && pytest tests/ -v
 	@echo "Testing Ruby service..."
 	cd ruby-service && bundle exec rspec spec/
+	@echo "Testing PHP service fixture..."
+	@if [ -d "php-service" ]; then \
+		if command -v php >/dev/null 2>&1; then \
+			php -l php-service/public/index.php && php -l php-service/src/LegacyReportController.php; \
+		else \
+			echo "Skipping PHP fixture test; php is not installed"; \
+		fi; \
+	fi
 
 lint:
 	@echo "Linting Go service..."
@@ -32,18 +48,28 @@ lint:
 	cd python-service && flake8 src tests && black --check src tests
 	@echo "Linting Ruby service..."
 	cd ruby-service && bundle exec rubocop
+	@echo "Linting PHP service fixture..."
+	@if [ -d "php-service" ]; then \
+		if command -v php >/dev/null 2>&1; then \
+			php -l php-service/public/index.php >/dev/null && php -l php-service/src/LegacyReportController.php >/dev/null; \
+		else \
+			echo "Skipping PHP lint; php is not installed"; \
+		fi; \
+	fi
 
 run-all:
 	@echo "Starting all services..."
 	@cd go-service && go run cmd/main.go &
 	@cd python-service && python src/app.py &
 	@cd ruby-service && bundle exec rackup config.ru -p 8082 &
-	@echo "Services started. Go: :8080, Python: :8081, Ruby: :8082"
+	@if [ -d "php-service" ] && command -v php >/dev/null 2>&1; then cd php-service && php -S 0.0.0.0:8084 -t public >/tmp/test-repo-php-service.log 2>&1 & else echo "Skipping PHP service startup; php is not installed"; fi
+	@echo "Services started. Go: :8080, Python: :8081, Ruby: :8082, PHP: :8084"
 
 stop-all:
 	@pkill -f "go run cmd/main.go" || true
 	@pkill -f "python src/app.py" || true
 	@pkill -f "rackup config.ru" || true
+	@pkill -f "php -S 0.0.0.0:8084 -t public" || true
 	@echo "All services stopped"
 
 clean:
@@ -52,5 +78,5 @@ clean:
 	cd python-service && find . -type d -name __pycache__ -exec rm -r {} + 2>/dev/null || true
 	cd python-service && rm -rf .pytest_cache .coverage htmlcov .mypy_cache
 	cd ruby-service && rm -rf tmp/ log/*.log
+	@rm -f /tmp/test-repo-php-service.log
 	@echo "Clean complete"
-

--- a/README.md
+++ b/README.md
@@ -1,15 +1,16 @@
 # Polyglot Codebase - Multi-Language Code Review System
 
-A sophisticated multi-language microservices application built with **Go**, **Python**, **Ruby**, and **TypeScript** that provides comprehensive code analysis, review, and metrics calculation.
+A sophisticated multi-language microservices application built with **Go**, **Python**, **Ruby**, **PHP**, and **TypeScript** that provides comprehensive code analysis, review, and metrics calculation.
 
 ## Architecture
 
-This project consists of four microservices:
+This project consists of five microservices:
 
 1. **Go Service** (`go-service/`) - Fast code parsing, diff analysis, and metrics calculation
 2. **Python Service** (`python-service/`) - AI-powered code review with pattern detection and quality scoring
 3. **Ruby Service** (`ruby-service/`) - Web API aggregator that orchestrates the other services
-4. **JS/TS Service** (`js-service/`) - API Gateway with request routing, rate limiting, and service health monitoring
+4. **PHP Service** (`php-service/`) - Composer fixture service with legacy dependencies and intentionally unsafe patterns for scanner validation
+5. **JS/TS Service** (`js-service/`) - API Gateway with request routing, rate limiting, and service health monitoring
 
 ## Features
 
@@ -18,6 +19,7 @@ This project consists of four microservices:
 - **Code Metrics**: Lines of code, complexity, functions, classes analysis
 - **Code Review**: Automated code review with issue detection
 - **Quality Scoring**: Overall code quality scoring based on multiple factors
+- **PHP Scan Coverage**: Composer dependency, license, and CI-log fixtures for PHP integration testing
 - **RESTful APIs**: Clean REST APIs for all services
 - **CI/CD**: Complete GitHub Actions workflows for all languages
 
@@ -38,6 +40,11 @@ polyglot-codebase/
 │   ├── app/            # Application code
 │   ├── spec/           # RSpec tests
 │   └── Gemfile
+├── php-service/         # PHP fixture service
+│   ├── public/         # Built-in server entrypoint
+│   ├── src/            # Legacy PHP code patterns
+│   ├── composer.json   # Composer manifest
+│   └── composer.lock   # Composer lockfile with license metadata
 ├── js-service/          # TypeScript API Gateway
 │   ├── src/            # TypeScript source code
 │   ├── package.json    # Node.js dependencies
@@ -53,6 +60,7 @@ polyglot-codebase/
 - Go 1.21+
 - Python 3.10+
 - Ruby 3.2+
+- PHP 8.2+ and Composer 2.x
 - Node.js 20+ and npm
 - Docker and Docker Compose (optional)
 
@@ -111,6 +119,11 @@ docker-compose up --build
 - `POST /analyze` - Full code analysis (aggregates Go + Python)
 - `POST /diff` - Diff analysis with review
 - `POST /metrics` - Metrics with quality score
+
+### PHP Service (Port 8084)
+
+- `GET /` - Render legacy report output using request parameters
+- `GET /?filter=legacy&summary=...` - Exercise intentionally unsafe PHP patterns for scanner validation
 
 ### JS/TS API Gateway (Port 8083)
 
@@ -178,6 +191,13 @@ cd ruby-service
 bundle exec rspec spec/
 ```
 
+### PHP Fixture Checks
+
+```bash
+php -l php-service/public/index.php
+php -l php-service/src/LegacyReportController.php
+```
+
 ## Development
 
 ### Adding New Features
@@ -191,6 +211,7 @@ bundle exec rspec spec/
 - **Go**: Follow standard Go conventions, use `golangci-lint`
 - **Python**: Follow PEP 8, use `black` for formatting
 - **Ruby**: Follow Ruby style guide, use `rubocop`
+- **PHP**: Keep the fixture intentionally legacy and scan-heavy so PHP integrations have stable validation data
 - **TypeScript**: Follow TypeScript best practices, use `eslint` for linting
 
 ## License

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -88,6 +88,28 @@ jobs:
           fi
         displayName: 'Run Ruby Tests'
 
+  - job: QuickPhpFixtures
+    displayName: 'Quick PHP Fixture Logs'
+    condition: or(contains(variables['Build.SourceBranch'], 'codity'), eq(variables['Build.Reason'], 'PullRequest'))
+    steps:
+      - script: |
+          echo "Emitting fixture PHP scan logs..."
+          if [ -d "php-service" ]; then
+            cd php-service
+            echo '$ composer audit --format=json'
+            cat ci-fixtures/composer-audit.json
+            echo '$ phpstan analyse --error-format=json'
+            cat ci-fixtures/phpstan.json
+            echo '$ psalm --output-format=json'
+            cat ci-fixtures/psalm.json
+            echo '$ phpcs --report=json'
+            cat ci-fixtures/phpcs.json
+          else
+            echo "php-service directory not found"
+            exit 1
+          fi
+        displayName: 'Emit PHP fixture logs'
+
   - job: QuickJavaScriptTests
     displayName: 'Quick JavaScript/TypeScript Tests'
     condition: or(contains(variables['Build.SourceBranch'], 'codity'), eq(variables['Build.Reason'], 'PullRequest'))

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,6 +39,17 @@ services:
     networks:
       - polyglot-network
 
+  php-service:
+    build:
+      context: ./php-service
+      dockerfile: Dockerfile
+    ports:
+      - "8084:8084"
+    environment:
+      - PORT=8084
+    networks:
+      - polyglot-network
+
   js-service:
     build:
       context: ./js-service
@@ -61,4 +72,3 @@ services:
 networks:
   polyglot-network:
     driver: bridge
-

--- a/php-service/Dockerfile
+++ b/php-service/Dockerfile
@@ -1,0 +1,9 @@
+FROM php:8.2-cli-alpine
+
+WORKDIR /app
+
+COPY . .
+
+EXPOSE 8084
+
+CMD ["php", "-S", "0.0.0.0:8084", "-t", "public"]

--- a/php-service/ci-fixtures/composer-audit.json
+++ b/php-service/ci-fixtures/composer-audit.json
@@ -1,0 +1,39 @@
+{
+  "advisories": {
+    "symfony/http-foundation": [
+      {
+        "advisoryId": "PKSA-symfony-http-foundation-2019-10913",
+        "packageName": "symfony/http-foundation",
+        "title": "Legacy response handling allows reflected XSS",
+        "link": "https://packagist.org/packages/symfony/http-foundation/advisories?version=2.7.0",
+        "cve": "CVE-2019-10913",
+        "affectedVersions": ">=2.7.0,<2.7.49",
+        "reportedAt": "2019-04-16T00:00:00+00:00",
+        "sources": [
+          {
+            "name": "FriendsOfPHP/security-advisories",
+            "remoteId": "symfony/http-foundation/CVE-2019-10913"
+          }
+        ]
+      }
+    ],
+    "guzzlehttp/guzzle": [
+      {
+        "advisoryId": "PKSA-guzzlehttp-guzzle-2022-31091",
+        "packageName": "guzzlehttp/guzzle",
+        "title": "Cookie jar domain matching issue in older Guzzle releases",
+        "link": "https://packagist.org/packages/guzzlehttp/guzzle/advisories?version=6.3.0",
+        "cve": "CVE-2022-31091",
+        "affectedVersions": ">=6.0.0,<6.5.8",
+        "reportedAt": "2022-06-20T00:00:00+00:00",
+        "sources": [
+          {
+            "name": "GitHub Advisory Database",
+            "remoteId": "GHSA-q559-8m2m-g699"
+          }
+        ]
+      }
+    ]
+  },
+  "abandonedPackages": []
+}

--- a/php-service/ci-fixtures/phpcs.json
+++ b/php-service/ci-fixtures/phpcs.json
@@ -1,0 +1,39 @@
+{
+  "totals": {
+    "errors": 2,
+    "warnings": 1,
+    "fixable": 0
+  },
+  "files": {
+    "src/LegacyReportController.php": {
+      "errors": 2,
+      "warnings": 1,
+      "messages": [
+        {
+          "message": "Missing declare(strict_types=1) declaration.",
+          "source": "PHPCompatibility.Declarations.StrictTypes.MissingDeclaration",
+          "severity": 5,
+          "type": "WARNING",
+          "line": 1,
+          "column": 1
+        },
+        {
+          "message": "Use of deprecated function mysql_query().",
+          "source": "PHPCompatibility.FunctionUse.RemovedFunctions.mysql_queryDeprecatedRemoved",
+          "severity": 5,
+          "type": "ERROR",
+          "line": 11,
+          "column": 9
+        },
+        {
+          "message": "Direct use of $_REQUEST detected in output context.",
+          "source": "Security.Superglobals.DirectAccess",
+          "severity": 5,
+          "type": "ERROR",
+          "line": 22,
+          "column": 25
+        }
+      ]
+    }
+  }
+}

--- a/php-service/ci-fixtures/phpstan.json
+++ b/php-service/ci-fixtures/phpstan.json
@@ -1,0 +1,29 @@
+{
+  "totals": {
+    "errors": 3,
+    "file_errors": 1
+  },
+  "files": {
+    "src/LegacyReportController.php": {
+      "errors": 3,
+      "messages": [
+        {
+          "message": "Call to deprecated function mysql_query().",
+          "line": 11,
+          "ignorable": false
+        },
+        {
+          "message": "Unsafe use of $_GET in SQL string concatenation.",
+          "line": 8,
+          "ignorable": false
+        },
+        {
+          "message": "Result of eval() is not type-safe.",
+          "line": 18,
+          "ignorable": false
+        }
+      ]
+    }
+  },
+  "errors": []
+}

--- a/php-service/ci-fixtures/psalm.json
+++ b/php-service/ci-fixtures/psalm.json
@@ -1,0 +1,20 @@
+{
+  "issues": [
+    {
+      "severity": "error",
+      "type": "TaintedSql",
+      "message": "Detected tainted SQL input from $_GET['filter'].",
+      "file_name": "src/LegacyReportController.php",
+      "line_from": 8,
+      "line_to": 11
+    },
+    {
+      "severity": "error",
+      "type": "ForbiddenCode",
+      "message": "Use of eval() is forbidden in application code.",
+      "file_name": "src/LegacyReportController.php",
+      "line_from": 17,
+      "line_to": 18
+    }
+  ]
+}

--- a/php-service/composer.json
+++ b/php-service/composer.json
@@ -1,0 +1,24 @@
+{
+  "name": "test-org-codity/php-service",
+  "description": "Fixture PHP service for Composer vulnerability, license, and code-quality scan coverage",
+  "type": "project",
+  "license": "MIT",
+  "require": {
+    "php": "^8.2",
+    "symfony/http-foundation": "2.7.0",
+    "guzzlehttp/guzzle": "6.3.0",
+    "monolog/monolog": "1.17.2",
+    "tecnickcom/tcpdf": "6.2.13"
+  },
+  "require-dev": {
+    "phpunit/phpunit": "5.7.27",
+    "phpstan/phpstan": "1.10.15",
+    "vimeo/psalm": "5.15.0",
+    "squizlabs/php_codesniffer": "3.7.2"
+  },
+  "autoload": {
+    "psr-4": {
+      "PolyglotPhp\\": "src/"
+    }
+  }
+}

--- a/php-service/composer.lock
+++ b/php-service/composer.lock
@@ -1,0 +1,75 @@
+{
+  "_readme": [
+    "This lockfile is a fixture for Codity PHP scan coverage.",
+    "It intentionally includes legacy Composer packages and license metadata."
+  ],
+  "content-hash": "fixture-lockfile-for-codity-php-scan-coverage",
+  "packages": [
+    {
+      "name": "symfony/http-foundation",
+      "version": "v2.7.0",
+      "license": [
+        "MIT"
+      ]
+    },
+    {
+      "name": "guzzlehttp/guzzle",
+      "version": "6.3.0",
+      "license": [
+        "MIT"
+      ]
+    },
+    {
+      "name": "monolog/monolog",
+      "version": "1.17.2",
+      "license": [
+        "MIT"
+      ]
+    },
+    {
+      "name": "tecnickcom/tcpdf",
+      "version": "6.2.13",
+      "license": [
+        "LGPL-3.0-only"
+      ]
+    }
+  ],
+  "packages-dev": [
+    {
+      "name": "phpunit/phpunit",
+      "version": "v5.7.27",
+      "license": [
+        "BSD-3-Clause"
+      ]
+    },
+    {
+      "name": "phpstan/phpstan",
+      "version": "1.10.15",
+      "license": [
+        "MIT"
+      ]
+    },
+    {
+      "name": "vimeo/psalm",
+      "version": "5.15.0",
+      "license": [
+        "MIT"
+      ]
+    },
+    {
+      "name": "squizlabs/php_codesniffer",
+      "version": "3.7.2",
+      "license": [
+        "BSD-3-Clause"
+      ]
+    }
+  ],
+  "aliases": [],
+  "minimum-stability": "stable",
+  "stability-flags": {},
+  "prefer-stable": false,
+  "prefer-lowest": false,
+  "platform": {},
+  "platform-dev": {},
+  "plugin-api-version": "2.6.0"
+}

--- a/php-service/public/index.php
+++ b/php-service/public/index.php
@@ -1,0 +1,8 @@
+<?php
+
+require_once __DIR__ . '/../src/LegacyReportController.php';
+
+use PolyglotPhp\LegacyReportController;
+
+$controller = new LegacyReportController();
+$controller->renderReport($_REQUEST);

--- a/php-service/src/LegacyReportController.php
+++ b/php-service/src/LegacyReportController.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace PolyglotPhp;
+
+class LegacyReportController
+{
+    public function renderReport(array $request): void
+    {
+        $filter = $_GET['filter'] ?? 'all';
+        $query = "SELECT * FROM reports WHERE type = '" . $filter . "'";
+
+        mysql_query($query);
+
+        if (isset($request['debug'])) {
+            print_r($request);
+        }
+
+        if (!empty($request['template'])) {
+            eval('$snippet = "' . $request['template'] . '";');
+        }
+
+        echo "<h1>Legacy PHP Report</h1>";
+        echo "<div>" . $_REQUEST['summary'] . "</div>";
+        echo "<pre>" . ($_POST['details'] ?? 'no details') . "</pre>";
+    }
+}

--- a/php-service/src/LegacyReportController.php
+++ b/php-service/src/LegacyReportController.php
@@ -7,16 +7,17 @@ class LegacyReportController
     public function renderReport(array $request): void
     {
         $filter = $_GET['filter'] ?? 'all';
+        // FIXTURE: intentional SQL injection pattern for scanner testing
         $query = "SELECT * FROM reports WHERE type = '" . $filter . "'";
 
-        mysql_query($query);
+        // FIXTURE: mysql_query($query);
 
         if (isset($request['debug'])) {
             print_r($request);
         }
 
         if (!empty($request['template'])) {
-            eval('$snippet = "' . $request['template'] . '";');
+            // FIXTURE: eval('$snippet = "' . $request['template'] . '";');
         }
 
         echo "<h1>Legacy PHP Report</h1>";


### PR DESCRIPTION
## **CodeAnt-AI Description**
Add a PHP fixture service and include it in local and CI checks

### What Changed
- Added a new PHP service that runs on port 8084 and serves a legacy report page for scanner and integration testing
- Updated local build, test, and lint flows to check the PHP fixture when PHP is installed, and to start/stop it with the other services
- Updated Docker Compose and the README so the PHP service is part of the documented setup
- Added CI steps that print fixed PHP security and code-quality scan logs for the fixture

### Impact
`✅ PHP scanner coverage in CI`
`✅ Local checks for the PHP fixture`
`✅ One more service available in the polyglot stack`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added PHP microservice on port 8084 with Docker support.
  * Extended build, test, and lint pipelines with PHP code validation.

* **Tests**
  * Integrated PHP fixture checks into the CI pipeline.

* **Documentation**
  * Updated project architecture and prerequisites to include PHP 8.2+ and Composer 2.x.
  * Added PHP Service API endpoints documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->