### PR TITLE
Add .NET security scan fixture

### DIFF
--- a/.github/workflows/dotnet-security-fixture.yml
+++ b/.github/workflows/dotnet-security-fixture.yml
@@ -1,0 +1,27 @@
+name: .NET Security Fixture
+
+on:
+  pull_request:
+    paths:
+      - "dotnet-service/**"
+      - ".github/workflows/dotnet-security-fixture.yml"
+
+jobs:
+  dotnet-audit:
+    name: NuGet vulnerability audit
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: "8.0.x"
+
+      - name: Restore fixture
+        run: dotnet restore dotnet-service/DotNetSecurityFixture.sln --force-evaluate
+
+      - name: Print NuGet vulnerability audit JSON
+        run: |
+          dotnet list dotnet-service/src/DotNetSecurityFixture/DotNetSecurityFixture.csproj package --vulnerable --include-transitive --format json || true

--- a/README.md
+++ b/README.md
@@ -1,15 +1,16 @@
 # Polyglot Codebase - Multi-Language Code Review System
 
-A sophisticated multi-language microservices application built with **Go**, **Python**, **Ruby**, and **TypeScript** that provides comprehensive code analysis, review, and metrics calculation.
+A sophisticated multi-language microservices application built with **Go**, **Python**, **Ruby**, **TypeScript**, and **.NET/C#** that provides comprehensive code analysis, review, and metrics calculation.
 
 ## Architecture
 
-This project consists of four microservices:
+This project consists of five microservices and fixtures:
 
 1. **Go Service** (`go-service/`) - Fast code parsing, diff analysis, and metrics calculation
 2. **Python Service** (`python-service/`) - AI-powered code review with pattern detection and quality scoring
 3. **Ruby Service** (`ruby-service/`) - Web API aggregator that orchestrates the other services
 4. **JS/TS Service** (`js-service/`) - API Gateway with request routing, rate limiting, and service health monitoring
+5. **.NET/C# Fixture** (`dotnet-service/`) - NuGet dependency, license, and SAST scan verification fixture
 
 ## Features
 
@@ -42,6 +43,10 @@ polyglot-codebase/
 │   ├── src/            # TypeScript source code
 │   ├── package.json    # Node.js dependencies
 │   └── tsconfig.json   # TypeScript configuration
+├── dotnet-service/      # .NET/C# security scan fixture
+│   ├── Directory.Packages.props
+│   ├── DotNetSecurityFixture.sln
+│   └── src/            # ASP.NET test app with NuGet dependencies
 ├── .github/workflows/   # CI/CD pipelines
 └── docker-compose.yml   # Docker orchestration
 ```
@@ -54,6 +59,7 @@ polyglot-codebase/
 - Python 3.10+
 - Ruby 3.2+
 - Node.js 20+ and npm
+- .NET SDK 8.0+
 - Docker and Docker Compose (optional)
 
 ### Local Development
@@ -176,6 +182,14 @@ pytest tests/ -v
 ```bash
 cd ruby-service
 bundle exec rspec spec/
+```
+
+### .NET Fixture
+
+```bash
+cd dotnet-service
+dotnet restore DotNetSecurityFixture.sln --force-evaluate
+dotnet list src/DotNetSecurityFixture/DotNetSecurityFixture.csproj package --vulnerable --include-transitive --format json
 ```
 
 ## Development

--- a/dotnet-service/Directory.Build.props
+++ b/dotnet-service/Directory.Build.props
@@ -1,0 +1,6 @@
+<Project>
+  <PropertyGroup>
+    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
+    <AnalysisLevel>latest</AnalysisLevel>
+  </PropertyGroup>
+</Project>

--- a/dotnet-service/Directory.Packages.props
+++ b/dotnet-service/Directory.Packages.props
@@ -1,0 +1,11 @@
+<Project>
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageVersion Include="Newtonsoft.Json" Version="12.0.1" />
+    <PackageVersion Include="System.Text.Encodings.Web" Version="4.5.0" />
+    <PackageVersion Include="System.Data.SqlClient" Version="4.8.5" />
+  </ItemGroup>
+</Project>

--- a/dotnet-service/DotNetSecurityFixture.sln
+++ b/dotnet-service/DotNetSecurityFixture.sln
@@ -1,0 +1,18 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DotNetSecurityFixture", "src\DotNetSecurityFixture\DotNetSecurityFixture.csproj", "{9E4FCE68-A2F8-4CF5-90D7-4E387D646F79}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{9E4FCE68-A2F8-4CF5-90D7-4E387D646F79}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9E4FCE68-A2F8-4CF5-90D7-4E387D646F79}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9E4FCE68-A2F8-4CF5-90D7-4E387D646F79}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9E4FCE68-A2F8-4CF5-90D7-4E387D646F79}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/dotnet-service/legacy/packages.config
+++ b/dotnet-service/legacy/packages.config
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Newtonsoft.Json" version="12.0.1" targetFramework="net48" />
+  <package id="System.Text.Encodings.Web" version="4.5.0" targetFramework="net48" />
+</packages>

--- a/dotnet-service/nuget.config
+++ b/dotnet-service/nuget.config
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
+  </packageSources>
+</configuration>

--- a/dotnet-service/src/DotNetSecurityFixture/Controllers/ReportController.cs
+++ b/dotnet-service/src/DotNetSecurityFixture/Controllers/ReportController.cs
@@ -1,0 +1,70 @@
+using System.Data.SqlClient;
+using System.Diagnostics;
+using System.Runtime.Serialization.Formatters.Binary;
+using System.Security.Cryptography;
+using System.Text;
+using Microsoft.AspNetCore.Mvc;
+using Newtonsoft.Json;
+
+namespace DotNetSecurityFixture.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public class ReportController : ControllerBase
+{
+    private const string ConnectionString = "Data Source=prod-sql;User ID=sa;Password=SuperSecret123!";
+
+    [HttpGet("search")]
+    public async Task<IActionResult> Search([FromQuery] string owner, [FromQuery] string callbackUrl)
+    {
+        using var connection = new SqlConnection(ConnectionString);
+        var query = $"SELECT * FROM Reports WHERE Owner = '{owner}'";
+        using var command = new SqlCommand(query, connection);
+
+        using var client = new HttpClient(new HttpClientHandler
+        {
+            ServerCertificateCustomValidationCallback = (message, cert, chain, errors) => true
+        });
+
+        var callbackResponse = await client.GetAsync(callbackUrl);
+        var auditRecord = JsonConvert.SerializeObject(new
+        {
+            owner,
+            callbackStatus = callbackResponse.StatusCode,
+            sql = command.CommandText
+        });
+
+        return Ok(auditRecord);
+    }
+
+    [HttpPost("run")]
+    public IActionResult RunCommand([FromBody] CommandRequest request)
+    {
+        Process.Start("cmd.exe", "/c " + request.Command);
+        return Ok(new { started = true });
+    }
+
+    [HttpPost("import")]
+    public IActionResult ImportPayload([FromBody] string base64Payload)
+    {
+        var bytes = Convert.FromBase64String(base64Payload);
+        using var stream = new MemoryStream(bytes);
+
+#pragma warning disable SYSLIB0011
+        var formatter = new BinaryFormatter();
+        var payload = formatter.Deserialize(stream);
+#pragma warning restore SYSLIB0011
+
+        return Ok(payload);
+    }
+
+    [HttpGet("hash")]
+    public IActionResult HashForDiagnostics([FromQuery] string input)
+    {
+        using var md5 = MD5.Create();
+        var hash = Convert.ToHexString(md5.ComputeHash(Encoding.UTF8.GetBytes(input)));
+        return Ok(new { hash });
+    }
+}
+
+public sealed record CommandRequest(string Command);

--- a/dotnet-service/src/DotNetSecurityFixture/DotNetSecurityFixture.csproj
+++ b/dotnet-service/src/DotNetSecurityFixture/DotNetSecurityFixture.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" />
+    <PackageReference Include="System.Text.Encodings.Web" />
+    <PackageReference Include="System.Data.SqlClient" />
+  </ItemGroup>
+</Project>

--- a/dotnet-service/src/DotNetSecurityFixture/Program.cs
+++ b/dotnet-service/src/DotNetSecurityFixture/Program.cs
@@ -1,0 +1,12 @@
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddControllers();
+
+var app = builder.Build();
+
+app.MapControllers();
+app.MapGet("/health", () => Results.Ok(new { status = "ok", service = "dotnet-security-fixture" }));
+
+app.Run();
+
+public partial class Program { }

--- a/dotnet-service/src/DotNetSecurityFixture/packages.lock.json
+++ b/dotnet-service/src/DotNetSecurityFixture/packages.lock.json
@@ -1,0 +1,25 @@
+{
+  "version": 1,
+  "dependencies": {
+    "net8.0": {
+      "Newtonsoft.Json": {
+        "type": "Direct",
+        "requested": "[12.0.1, )",
+        "resolved": "12.0.1",
+        "contentHash": "fixture-lockfile-entry"
+      },
+      "System.Text.Encodings.Web": {
+        "type": "Direct",
+        "requested": "[4.5.0, )",
+        "resolved": "4.5.0",
+        "contentHash": "fixture-lockfile-entry"
+      },
+      "System.Data.SqlClient": {
+        "type": "Direct",
+        "requested": "[4.8.5, )",
+        "resolved": "4.8.5",
+        "contentHash": "fixture-lockfile-entry"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add a .NET/C# fixture service with NuGet central package management, a project lockfile, NuGet config, and legacy packages.config
- include intentionally vulnerable NuGet package versions for dependency vulnerability testing
- add C# code paths intended to exercise SAST checks for hardcoded connection strings, SQL interpolation, disabled TLS validation, SSRF, command execution, BinaryFormatter deserialization, and MD5 usage
- add a GitHub Actions workflow that restores the fixture and prints NuGet vulnerability audit JSON without failing the PR

## What to test in Codity
- security scan should pick up C# SAST findings and NuGet dependency vulnerabilities
- license scan should parse NuGet dependencies and resolve package license metadata
- dashboard branch/PR scans should render .NET/NuGet results without schema changes

## Notes
- The fixture lockfile is intentionally static for parser coverage; the workflow uses dotnet restore --force-evaluate before printing audit output.
- Local dotnet CLI is not installed in this workspace, so JSON and patch hygiene were validated locally but dotnet restore was not run.