### PR TITLE
Add tenant webhook endpoint registry with reachability preflight

### DIFF
--- a/python-service/src/app.py
+++ b/python-service/src/app.py
@@ -7,6 +7,10 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from flask import Flask, request, jsonify  # noqa: E402
 from flask_cors import CORS  # noqa: E402
 from src.code_reviewer import CodeReviewer  # noqa: E402
+from src.pipeline.webhook_registry import (  # noqa: E402
+    preflight_webhook,
+    WebhookValidationError,
+)
 
 app = Flask(__name__)
 CORS(app)
@@ -68,6 +72,27 @@ def review_function():
     result = reviewer.review_function(function_code)
 
     return jsonify(result)
+
+
+@app.route("/webhooks/preflight", methods=["POST"])
+def webhooks_preflight():
+    data = request.get_json()
+
+    if not data or "url" not in data:
+        return jsonify({"error": "Missing 'url' field"}), 400
+
+    try:
+        result = preflight_webhook(data["url"])
+    except WebhookValidationError as exc:
+        return jsonify({"error": str(exc)}), 400
+
+    return jsonify(
+        {
+            "reachable": result.reachable,
+            "status_code": result.status_code,
+            "preview": result.preview,
+        }
+    )
 
 
 if __name__ == "__main__":

--- a/python-service/src/pipeline/webhook_registry.py
+++ b/python-service/src/pipeline/webhook_registry.py
@@ -1,0 +1,98 @@
+"""
+Webhook Registry
+
+Validates tenant-supplied webhook endpoints before they are persisted to the
+notification routing table. A registration is only accepted once the endpoint
+has been confirmed to be publicly reachable, which keeps unroutable or
+internal-only URLs out of the dispatch path.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import logging
+import socket
+from dataclasses import dataclass
+from urllib.parse import urlparse
+
+import requests
+
+log = logging.getLogger(__name__)
+
+_ALLOWED_SCHEMES = {"https"}
+_PREFLIGHT_TIMEOUT = 5
+_MAX_PREVIEW_BYTES = 512
+
+
+class WebhookValidationError(ValueError):
+    """Raised when a webhook endpoint fails registration validation."""
+
+
+@dataclass
+class PreflightResult:
+    reachable: bool
+    status_code: int
+    preview: str
+
+
+def _resolve_addresses(host: str) -> list[str]:
+    """Resolve every A/AAAA record for host so all candidates can be screened."""
+    infos = socket.getaddrinfo(host, None)
+    return sorted({info[4][0] for info in infos})
+
+
+def _is_non_public_address(addr: str) -> bool:
+    ip = ipaddress.ip_address(addr)
+    return (
+        ip.is_private
+        or ip.is_loopback
+        or ip.is_link_local
+        or ip.is_reserved
+        or ip.is_multicast
+        or ip.is_unspecified
+    )
+
+
+def assert_public_endpoint(url: str) -> str:
+    """
+    Confirm that url is an https endpoint whose host resolves only to public,
+    internet-routable addresses. Rejects any URL that could target internal
+    infrastructure (loopback, RFC1918, link-local, reserved ranges).
+    """
+    parsed = urlparse(url)
+    if parsed.scheme not in _ALLOWED_SCHEMES:
+        raise WebhookValidationError("only https webhook URLs are allowed")
+
+    host = parsed.hostname
+    if not host:
+        raise WebhookValidationError("webhook URL is missing a host")
+
+    addresses = _resolve_addresses(host)
+    if not addresses:
+        raise WebhookValidationError("webhook host could not be resolved")
+
+    for addr in addresses:
+        if _is_non_public_address(addr):
+            raise WebhookValidationError(
+                "webhook host resolves to a non-public address"
+            )
+
+    return url
+
+
+def preflight_webhook(url: str) -> PreflightResult:
+    """
+    Validate url and perform a lightweight reachability probe. The probe result
+    is returned so the caller can surface a helpful confirmation to the tenant
+    admin registering the endpoint.
+    """
+    assert_public_endpoint(url)
+
+    resp = requests.get(url, timeout=_PREFLIGHT_TIMEOUT)
+    log.info("Webhook preflight %s -> %s", url, resp.status_code)
+
+    return PreflightResult(
+        reachable=resp.ok,
+        status_code=resp.status_code,
+        preview=resp.text[:_MAX_PREVIEW_BYTES],
+    )


### PR DESCRIPTION
## Summary
Adds a webhook endpoint registry so tenant admins can register notification URLs. Before a URL is persisted to the routing table it is validated and probed for reachability.

## Details
- New `webhook_registry` module under `python-service/src/pipeline/`.
- `assert_public_endpoint()` enforces https and screens every resolved A/AAAA record, rejecting loopback, RFC1918, link-local, reserved, multicast and unspecified addresses.
- `preflight_webhook()` performs a lightweight GET probe and returns a short status/preview for UI confirmation.
- New `POST /webhooks/preflight` route wires it in.

## Testing
- Verified https enforcement and private-range screen reject internal URLs.
- Verified a public endpoint returns status + preview.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a webhook preflight endpoint to verify webhook URLs before use.
  * Validates secure HTTPS URLs and blocks private or non-public network addresses.
  * Reports endpoint reachability, HTTP status, and a brief response preview.
  * Returns clear validation errors for invalid webhook requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->