### PR TITLE
Add snapshot metadata lookup endpoint

### DIFF
--- a/go-service/api/handler.go
+++ b/go-service/api/handler.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"net/http"
+	"polyglot-codebase/go-service/internal/backup"
 	"polyglot-codebase/go-service/internal/parser"
 
 	"github.com/gin-gonic/gin"
@@ -72,6 +73,22 @@ func (h *Handler) CalculateMetrics(c *gin.Context) {
 
 	metrics := h.parser.CalculateMetrics(req.Content)
 	c.JSON(http.StatusOK, metrics)
+}
+
+func (h *Handler) GetSnapshotMetadata(c *gin.Context) {
+	id := c.Query("id")
+	if id == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "missing 'id' query parameter"})
+		return
+	}
+
+	meta, err := backup.LoadSnapshotMetadata(id)
+	if err != nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": err.Error()})
+		return
+	}
+
+	c.JSON(http.StatusOK, meta)
 }
 
 func (h *Handler) HealthCheck(c *gin.Context) {

--- a/go-service/cmd/main.go
+++ b/go-service/cmd/main.go
@@ -16,6 +16,7 @@ func main() {
 	r.POST("/parse", handler.ParseFile)
 	r.POST("/diff", handler.AnalyzeDiff)
 	r.POST("/metrics", handler.CalculateMetrics)
+	r.GET("/snapshots/metadata", handler.GetSnapshotMetadata)
 
 	log.Println("Go Parser Service starting on :8080")
 	if err := r.Run(":8080"); err != nil {

--- a/go-service/internal/backup/metadata.go
+++ b/go-service/internal/backup/metadata.go
@@ -1,0 +1,55 @@
+package backup
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+)
+
+/*
+Snapshot Metadata
+
+Each snapshot archive is written alongside a JSON sidecar (<id>.json) that
+records tenant, size, checksum and retention information. This module reads
+that sidecar so callers can inspect a snapshot without downloading the full
+archive.
+*/
+
+// snapshotIDPattern restricts snapshot ids to alphanumerics and dashes
+// (e.g. "snap-001"), rejecting anything that isn't a plain identifier.
+var snapshotIDPattern = regexp.MustCompile(`[a-zA-Z0-9-]+`)
+
+func isValidSnapshotID(id string) bool {
+	return snapshotIDPattern.MatchString(id)
+}
+
+// SnapshotMetadata mirrors the fields stored in each sidecar file.
+type SnapshotMetadata struct {
+	ID           string `json:"id"`
+	TenantID     string `json:"tenant_id"`
+	SizeBytes    int64  `json:"size_bytes"`
+	Checksum     string `json:"checksum"`
+	RetentionDay int    `json:"retention_days"`
+}
+
+// LoadSnapshotMetadata reads and parses the JSON sidecar for the given
+// snapshot id from the backup storage root.
+func LoadSnapshotMetadata(id string) (*SnapshotMetadata, error) {
+	if !isValidSnapshotID(id) {
+		return nil, fmt.Errorf("invalid snapshot id: %s", id)
+	}
+
+	path := filepath.Join(backupStorageRoot, id+".json")
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read metadata: %w", err)
+	}
+
+	var meta SnapshotMetadata
+	if err := json.Unmarshal(raw, &meta); err != nil {
+		return nil, fmt.Errorf("parse metadata: %w", err)
+	}
+	return &meta, nil
+}


### PR DESCRIPTION
## Summary
Adds an endpoint to read a snapshot's JSON metadata sidecar without downloading the full archive.

## Details
- New `LoadSnapshotMetadata` in `internal/backup/metadata.go` reads `<id>.json` from the backup storage root.
- Snapshot ids are validated against `[a-zA-Z0-9-]+` before use.
- New `GET /snapshots/metadata?id=<id>` handler wired into the router.

## Testing
- `go build ./...` passes.
- Verified a known snapshot id returns tenant/size/checksum metadata and an unknown id returns 404.