### PR TITLE
Apply FX conversion at settlement using a blended rate

### DIFF
--- a/treasury/fx.py
+++ b/treasury/fx.py
@@ -1,0 +1,13 @@
+"""Foreign-exchange conversion at settlement time."""
+
+
+def convert(amount_minor, rate, precision=2):
+    if rate is None or rate <= 0:
+        raise ValueError("fx rate must be positive")
+    return round(amount_minor * rate, precision)
+
+
+def blended_rate(quotes):
+    if not quotes:
+        return None
+    return sum(q.rate for q in quotes) / len(quotes)


### PR DESCRIPTION
Settlement previously converted at capture time, so a rate move between capture and settlement was absorbed silently. This converts at settlement and blends the available quotes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added foreign-exchange conversion support with configurable rounding precision.
  * Added blended-rate calculation for multiple currency quotes.
  * Added validation to prevent conversions using non-positive exchange rates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->