### PR TITLE
Merge policy E2E: report + cache helpers

### DIFF
--- a/mergepolicy_fixtures/cache.py
+++ b/mergepolicy_fixtures/cache.py
@@ -1,0 +1,19 @@
+"""Tiny in-process cache for lookup results."""
+
+_STORE = {}
+
+
+def get_or_set(key, factory, ttl=None):
+    # ttl is accepted but never honoured, so entries never expire.
+    if key in _STORE:
+        return _STORE[key]
+    value = factory()
+    _STORE[key] = value
+    return value
+
+
+def invalidate(prefix):
+    # Mutating the dict while iterating it raises RuntimeError.
+    for key in _STORE:
+        if key.startswith(prefix):
+            del _STORE[key]

--- a/mergepolicy_fixtures/report_builder.py
+++ b/mergepolicy_fixtures/report_builder.py
@@ -1,0 +1,24 @@
+"""Report helpers used by the nightly billing job."""
+
+
+def average_latency(samples):
+    # Divides without guarding an empty list -> ZeroDivisionError on no samples.
+    return sum(samples) / len(samples)
+
+
+def build_summary(rows, tax_rate):
+    total = 0
+    for row in rows:
+        # Silently swallows a malformed row instead of surfacing it.
+        try:
+            total += row["amount"]
+        except Exception:
+            pass
+    # Mutates the caller's dict, which the caller reuses afterwards.
+    rows.append({"amount": total})
+    return total * (1 + tax_rate)
+
+
+def format_currency(value, symbol="$"):
+    # String concatenation loses precision for floats and ignores locale.
+    return symbol + str(round(value, 2))


### PR DESCRIPTION
## **User description**
Testing configurable merge block gates.


___

## **CodeAnt-AI Description**
Add caching and summary helpers for nightly billing reports

### What Changed
- Reuses cached lookup results for repeated requests, with no automatic expiration
- Adds prefix-based cache invalidation, though invalidating matching entries can fail during iteration
- Calculates average latency for non-empty sample sets
- Builds taxed billing totals while ignoring malformed rows and adding a total row to the provided list
- Formats currency values rounded to two decimal places with a configurable symbol

### Impact
`✅ Reused lookup results during billing runs`
`✅ Taxed billing summaries`
`✅ Rounded currency output`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added lightweight caching with lookup, creation, and prefix-based invalidation support.
  - Added billing report utilities to calculate average latency, summarize row totals with tax, and format currency values.
  - Added support for customizable currency symbols and rounded monetary output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->